### PR TITLE
Fix .gitignore and MANIFEST.SKIP to refuse recursive self-inclusion.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,4 +19,4 @@ nytprof.out
 *.o
 *.bs
 /_eumm/
-/Tree-Simple-*.gz
+/Tree-Simple-*

--- a/MANIFEST.SKIP
+++ b/MANIFEST.SKIP
@@ -43,3 +43,5 @@
 
 ^MYMETA.yml$
 ^MYMETA\.json$
+
+^Tree-Simple-.*


### PR DESCRIPTION
This is to prevent any such residual dirs ever turning up in MANIFEST
and ever end up recursively inside ourselves.

Proper use of workflow and git clean should avoid this, but this
prevents it happening even in accidental circumstances.